### PR TITLE
Fix error message mentionning graphicsmagick instead of imagemagick

### DIFF
--- a/src/adapters/pdfpages.rs
+++ b/src/adapters/pdfpages.rs
@@ -70,7 +70,7 @@ impl FileAdapter for PdfPagesAdapter {
 			.arg(out_fname);
 
 		let mut cmd = cmd.spawn().map_err(|e| {
-			map_exe_error(e, exe_name, "Make sure you have graphicsmagick installed.")
+			map_exe_error(e, exe_name, "Make sure you have imagemagick installed.")
 		})?;
 		let args = config.args;
 


### PR DESCRIPTION
The error message mentions `graphicsmagick`, but the program actually calls `convert` which is provided by `imagemagick`.
You can have graphicsmagick "installed as imagemagick" (eg: https://aur.archlinux.org/packages/graphicsmagick-imagemagick-compat/), but I think it would be less confusing just mentionning imagemagick.