### PR TITLE
fix help for --rga-cache-max-blob-len

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -80,7 +80,8 @@ pub struct RgaArgs {
     #[structopt(
         long = "--rga-cache-max-blob-len",
         default_value = "2000000",
-        hidden_short_help = true
+        hidden_short_help = true,
+        require_equals = true
     )]
     /// Max compressed size to cache
     ///


### PR DESCRIPTION
Since the arguments are preprocessed in `split_args`, all option arguments must
use equals. This was missing for --rga-cache-max-blob-len and the help was then
misleading:

        --rga-cache-max-blob-len <cache-max-blob-len>
            Max compressed size to cache