### PR TITLE
Add jar to zip adapter

### DIFF
--- a/src/adapters/zip.rs
+++ b/src/adapters/zip.rs
@@ -4,7 +4,7 @@ use anyhow::*;
 use lazy_static::lazy_static;
 use log::*;
 
-static EXTENSIONS: &[&str] = &["zip"];
+static EXTENSIONS: &[&str] = &["zip", "jar"];
 
 lazy_static! {
     static ref METADATA: AdapterMeta = AdapterMeta {


### PR DESCRIPTION
[`.jar` is `.zip`](https://en.wikipedia.org/wiki/JAR_(file_format)).

So I add '.jar' to *zip* adapter's extensions.
