### PR TITLE
add disabled gron adapter for JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you get an error like `VCRUNTIME140.DLL could not be found`, you need to inst
 
 To install the dependencies that are each not strictly necessary but very useful:
 
-`brew install pandoc poppler tesseract ffmpeg`
+`brew install gron pandoc poppler tesseract ffmpeg`
 
 ### Compile from source
 
@@ -133,7 +133,15 @@ Adapters:
 
     Mime Types: application/x-sqlite3
 
-The following adapters are disabled by default, and can be enabled using '--rga-adapters=+pdfpages,tesseract':
+The following adapters are disabled by default, and can be enabled using '--rga-adapters=+gron,pdfpages,tesseract':
+
+-   **gron**
+
+    Flattens JSON to provide the full structure on each line.
+
+    Extensions: .json
+
+    Mime Types: application/json
 
 -   **pdfpages**
 

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -1,5 +1,6 @@
 pub mod decompress;
 pub mod ffmpeg;
+pub mod gron;
 pub mod pandoc;
 pub mod pdfpages;
 pub mod poppler;
@@ -91,6 +92,7 @@ pub fn get_all_adapters() -> AdaptersTuple {
         Rc::new(sqlite::SqliteAdapter::new()),
     ];
     let disabled_adapters: Vec<Rc<dyn FileAdapter>> = vec![
+        Rc::new(gron::GronAdapter::new()),
         Rc::new(pdfpages::PdfPagesAdapter::new()),
         Rc::new(tesseract::TesseractAdapter::new()),
     ];

--- a/src/adapters/gron.rs
+++ b/src/adapters/gron.rs
@@ -1,0 +1,45 @@
+use super::*;
+use lazy_static::lazy_static;
+use spawning::SpawningFileAdapter;
+use std::process::Command;
+
+static EXTENSIONS: &[&str] = &["json"];
+
+lazy_static! {
+    static ref METADATA: AdapterMeta = AdapterMeta {
+        name: "gron".to_owned(),
+        version: 1,
+        description: "Uses gron to flatten JSON files to make their structure searchable by line.".to_owned(),
+        recurses: false,
+        fast_matchers: EXTENSIONS
+            .iter()
+            .map(|s| FastMatcher::FileExtension(s.to_string()))
+            .collect(),
+        slow_matchers: Some(vec![SlowMatcher::MimeType(
+            "application/json".to_owned()
+        )])
+    };
+}
+#[derive(Default)]
+pub struct GronAdapter {}
+
+impl GronAdapter {
+    pub fn new() -> GronAdapter {
+        GronAdapter {}
+    }
+}
+
+impl GetMetadata for GronAdapter {
+    fn metadata(&self) -> &AdapterMeta {
+        &METADATA
+    }
+}
+impl SpawningFileAdapter for GronAdapter {
+    fn get_exe(&self) -> &str {
+        "gron"
+    }
+    fn command(&self, _filepath_hint: &Path, mut cmd: Command) -> Command {
+        cmd.arg("--monochrome").arg("-");
+        cmd
+    }
+}


### PR DESCRIPTION
This adapter operates on plaintext files and gives different results than plain `rg` on those files, so I have added it only as a non-default adapter.

The patch is built against tag [v0.9.6.](https://github.com/phiresky/ripgrep-all/releases/tag/v0.9.6)  I've tested it locally and it seems to work correctly.