### PR TITLE
Revert "Fix error message mentionning graphicsmagick instead of imagemagick"

### DIFF
--- a/src/adapters/pdfpages.rs
+++ b/src/adapters/pdfpages.rs
@@ -73,7 +73,7 @@ impl FileAdapter for PdfPagesAdapter {
 
         let mut cmd = cmd
             .spawn()
-            .map_err(|e| map_exe_error(e, exe_name, "Make sure you have imagemagick installed."))?;
+            .map_err(|e| map_exe_error(e, exe_name, "Make sure you have graphicsmagick installed."))?;
         let args = config.args;
 
         let status = cmd.wait()?;


### PR DESCRIPTION
As mentioned in [a followup comment](https://github.com/phiresky/ripgrep-all/pull/19#issuecomment-633287929) when this change from "graphicsmagick" to "imagemagick" was originally merged, the code does currently call `gm` (src/adapters/pdfpages.rs:62) and so does, in fact, need the "graphicsmagick" package.

This reverts commit 6d2df9162c4498a2968997b13ebd802498b4bd6d.