### PR TITLE
add docker option for installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ $ $EDITOR /usr/local/share/dockerfiles/rga/Dockerfile
 ```sh
 FROM nixos/nix
 RUN nix-env -iA nixpkgs.ripgrep-all
-ENTRYPOINT ["rga"]
+ENTRYPOINT ["rga", "--rga-no-cache"]
 ```
 3. create a script in your `$PATH`.
 ```sh


### PR DESCRIPTION
hi,
i love ripgrep-all. helps me immensely with my studies.
i want to contribute a way to run `rga` in a container as if it where natively installed.
---
rga will be "installed" in a nixos-container (best package manager). and a script handles execution.
that way integration with other programs(fzf) should work too.
- when calling `rga` this way, on the first run the container is build in the background.