### PR TITLE
fix build with stable rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,15 @@ jobs:
     strategy:
       matrix:
         build:
+        - stable
         - nightly
         - nightly-musl
         - nightly-arm
         - macos
         include:
-        #- build: stable
-        #  os: ubuntu-18.04
-        #  rust: stable
+        - build: stable
+          os: ubuntu-18.04
+          rust: stable
         - build: nightly
           os: ubuntu-18.04
           rust: nightly

--- a/src/adapters/postproc.rs
+++ b/src/adapters/postproc.rs
@@ -158,7 +158,10 @@ impl Read for ReadErr {
     }
 }*/
 
-pub fn postproc_encoding<'a, R: Read+'a>(line_prefix: &str, inp: R) -> Result<Box<dyn Read + 'a>> {
+pub fn postproc_encoding<'a, R: Read + 'a>(
+    line_prefix: &str,
+    inp: R,
+) -> Result<Box<dyn Read + 'a>> {
     // TODO: parse these options from ripgrep's configuration
     let encoding = None; // detect bom but usually assume utf8
     let bom_sniffing = true;
@@ -184,9 +187,7 @@ pub fn postproc_encoding<'a, R: Read+'a>(line_prefix: &str, inp: R) -> Result<Bo
     if fourk.contains(&0u8) {
         log::debug!("detected binary");
         let v = "[rga: binary data]";
-        return Ok(Box::new(std::io::Cursor::new(
-            v
-        )));
+        return Ok(Box::new(std::io::Cursor::new(v)));
         /*let err = std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!("{}[rga: binary data]", line_prefix),
@@ -280,7 +281,12 @@ mod tests {
 
         test_from_strs(false, "foo.pdf:", inp, oup)?;
 
-        test_from_strs(false, "foo:", "this is a test \n\n \0 foo", "foo:[rga: binary data]")?;
+        test_from_strs(
+            false,
+            "foo:",
+            "this is a test \n\n \0 foo",
+            "foo:[rga: binary data]",
+        )?;
         test_from_strs(false, "foo:", "\0", "foo:[rga: binary data]")?;
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![warn(clippy::all)]
-#![feature(negative_impls)]
 
 pub mod adapted_iter;
 pub mod adapters;

--- a/src/preproc_cache.rs
+++ b/src/preproc_cache.rs
@@ -21,7 +21,9 @@ pub trait PreprocCache: Send + Sync {
 }
 
 /// opens a LMDB cache
-fn open_cache_db(path: &Path) -> Result<std::sync::Arc<std::sync::RwLock<rkv::Rkv<LmdbEnvironment>>>> {
+fn open_cache_db(
+    path: &Path,
+) -> Result<std::sync::Arc<std::sync::RwLock<rkv::Rkv<LmdbEnvironment>>>> {
     std::fs::create_dir_all(path)?;
     use rkv::backend::LmdbEnvironmentFlags;
 


### PR DESCRIPTION
To make this build with the rustc in Debian testing (1.57.0), all I had to do was to remove `#![feature(negative_impls)]`.

I also enabled stable in the CI matrix and fixed the rustfmt errors and CI is green in my branch. I still expect it to fail for the pull request, however, due to https://github.com/phiresky/ripgrep-all/commit/2d63efd3156a2eca633b1b43d67931fe1cb0df6e.