### PR TITLE
ffmpeg adapter: added support for processing all subtitle streams

### DIFF
--- a/src/adapters/ffmpeg.rs
+++ b/src/adapters/ffmpeg.rs
@@ -14,7 +14,7 @@ use writing::WritingFileAdapter;
 // maybe todo: read list of extensions from
 // ffmpeg -demuxers | tail -n+5 | awk '{print $2}' | while read demuxer; do echo MUX=$demuxer; ffmpeg -h demuxer=$demuxer | grep 'Common extensions'; done 2>/dev/null
 // but really, the probability of getting useful information from a .flv is low
-static EXTENSIONS: &[&str] = &["mkv", "mp4", "avi", "mp3", "ogg", "flac"];
+static EXTENSIONS: &[&str] = &["mkv", "mp4", "avi", "mp3", "ogg", "flac", "webm"];
 
 lazy_static! {
     static ref METADATA: AdapterMeta = AdapterMeta {


### PR DESCRIPTION
ffprobe supports enumerating all indices of subtitle streams.  Use this for processing all subtitle streams.

Useful when the first (default) stream does not include full captions and/or is not in the expected language.