### PR TITLE
Tighten CI by running in Nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: ci
 
 jobs:
   nix-flake-check:
-    name: Lints
+    name: nix flake check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,69 +1,25 @@
 # Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
 #
-# While our "example" application has the platform-specific code,
-# for simplicity we are compiling and testing everything on the Ubuntu environment only.
-# For multi-OS testing see the `cross.yml` workflow.
+# While our "example" application has platform-specific code,
+# for simplicity we are compiling and testing everything in a nix-on-Linux environment only.
 
 on: [push, pull_request]
 
 name: ci
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-
-  test:
-    name: Test Suite
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install nix
-        uses: cachix/install-nix-action@v18
-
-      - name: Run tests
-        run: nix develop --command cargo test
-
-  lints:
+  nix-flake-check:
     name: Lints
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
+      - name: Install nix
+        uses: cachix/install-nix-action@v21
 
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - name: Ensure the build succeeds
+        run: nix build
 
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+      - name: Run `nix flake check` to run formatters, linters, and tests
+        run: nix flake check --print-build-logs

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1682282022,
-        "narHash": "sha256-qCMDFeWjANtpFKF0NEl6uVenfgruhSCnbnOMDO0WCzE=",
+        "lastModified": 1684873045,
+        "narHash": "sha256-MVXbXNXcqiaeJZbwVw6R16xqxJkpm+ipAIljz4/9QaM=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "5f4eca136204fb9e86d6297b20f149d225276824",
+        "rev": "e162556b9e8c1542c187290453cbd322e8905f0c",
         "type": "github"
       },
       "original": {
@@ -26,11 +26,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1681680516,
-        "narHash": "sha256-EB8Adaeg4zgcYDJn9sR6UMjN/OHdIiMMK19+3LmmXQY=",
+        "lastModified": 1684981077,
+        "narHash": "sha256-68X9cFm0RTZm8u0rXPbeBzOVUH5OoUGAfeHHVoxGd9o=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "54b63c8eae4c50172cb50b612946ff1d2bc1c75c",
+        "rev": "35110cccf28823320f4fd697fcafcb5038683982",
         "type": "github"
       },
       "original": {
@@ -72,12 +72,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -88,7 +91,7 @@
     },
     "flake-utils_2": {
       "inputs": {
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1681202837,
@@ -127,11 +130,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681706826,
-        "narHash": "sha256-OGTMgnGBDE7XV0AnR83zFXxPpgEEe44mVebFRMe9P2g=",
+        "lastModified": 1685249274,
+        "narHash": "sha256-oqo9yIloFeeeef3tRpxCQwE4ZZKRU055Zv30otw+IoE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "016a65fde03180d0c6e817da11b9c7bc8316a0ab",
+        "rev": "41bb263d28f1a3a3c4dbc6ce21d462cebd94ac71",
         "type": "github"
       },
       "original": {
@@ -169,11 +172,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1681831107,
-        "narHash": "sha256-pXl3DPhhul9NztSetUJw2fcN+RI3sGOYgKu29xpgnqw=",
+        "lastModified": 1684842236,
+        "narHash": "sha256-rYWsIXHvNhVQ15RQlBUv67W3YnM+Pd+DuXGMvCBq2IE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "b7ca8f6fff42f6af75c17f9438fed1686b7d855d",
+        "rev": "61e567d6497bc9556f391faebe5e410e6623217f",
         "type": "github"
       },
       "original": {
@@ -204,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680488274,
-        "narHash": "sha256-0vYMrZDdokVmPQQXtFpnqA2wEgCCUXf5a3dDuDVshn0=",
+        "lastModified": 1683080331,
+        "narHash": "sha256-nGDvJ1DAxZIwdn6ww8IFwzoHb2rqBP4wv/65Wt5vflk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7ec2ff598a172c6e8584457167575b3a1a5d80d8",
+        "rev": "d59c3fa0cba8336e115b376c2d9e91053aa59e56",
         "type": "github"
       },
       "original": {
@@ -227,11 +230,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682216676,
-        "narHash": "sha256-nClm9zj7Tk/uJ3b61GWPG8dBKdvsrYz4y4Kgpz+SB9Y=",
+        "lastModified": 1685240871,
+        "narHash": "sha256-bOCbP0lWTjhmrPcdyuFD/yx/38CKkzC2TNXmBzZSLJA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7e938508fee57a0c0603329f63ec0509c1ae9aad",
+        "rev": "aa1b08de9ca770534ad750dccc70cebd95c15e26",
         "type": "github"
       },
       "original": {
@@ -241,6 +244,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1684873045,
-        "narHash": "sha256-MVXbXNXcqiaeJZbwVw6R16xqxJkpm+ipAIljz4/9QaM=",
+        "lastModified": 1685821301,
+        "narHash": "sha256-4XRcnSboLJw1XKjDpg2jBU70jEw/8Bgx4nUmnq3kXbY=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "e162556b9e8c1542c187290453cbd322e8905f0c",
+        "rev": "af3f3d503f82056785841bee49997bae65eba1c0",
         "type": "github"
       },
       "original": {
@@ -94,11 +94,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685249274,
-        "narHash": "sha256-oqo9yIloFeeeef3tRpxCQwE4ZZKRU055Zv30otw+IoE=",
+        "lastModified": 1685860998,
+        "narHash": "sha256-ZexAPe8yvJaLvn5aVgjW0vY41RnmJGbgOdGBJk1yDIE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "41bb263d28f1a3a3c4dbc6ce21d462cebd94ac71",
+        "rev": "45d47b647d7bbaede5121d731cbee78f6093b6d6",
         "type": "github"
       },
       "original": {
@@ -172,11 +172,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1684842236,
-        "narHash": "sha256-rYWsIXHvNhVQ15RQlBUv67W3YnM+Pd+DuXGMvCBq2IE=",
+        "lastModified": 1685361114,
+        "narHash": "sha256-4RjrlSb+OO+e1nzTExKW58o3WRwVGpXwj97iCta8aj4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "61e567d6497bc9556f391faebe5e410e6623217f",
+        "rev": "ca2fdbf3edda2a38140184da6381d49f8206eaf4",
         "type": "github"
       },
       "original": {
@@ -230,11 +230,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685240871,
-        "narHash": "sha256-bOCbP0lWTjhmrPcdyuFD/yx/38CKkzC2TNXmBzZSLJA=",
+        "lastModified": 1685846256,
+        "narHash": "sha256-G4aYK4VqlMHImvZ0lUnLHw1A+Cx28T0sBMvAKZBcGpk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "aa1b08de9ca770534ad750dccc70cebd95c15e26",
+        "rev": "1ef3c6de6127a1cba94cc5492cdde52e33d06ea4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -64,10 +64,7 @@
 
         # Build the actual crate itself, reusing the dependency
         # artifacts from above.
-        rga = craneLib.buildPackage {
-          inherit cargoArtifacts src buildInputs;
-          doCheck = false;
-        };
+        rga = craneLib.buildPackage { inherit cargoArtifacts src buildInputs; };
 
         pre-commit = pre-commit-hooks.lib."${system}".run;
       in {
@@ -107,7 +104,6 @@
             hooks = {
               nixfmt.enable = true;
               rustfmt.enable = true;
-              cargo-check.enable = true;
               typos = {
                 enable = true;
                 types = [ "text" ];

--- a/flake.nix
+++ b/flake.nix
@@ -108,6 +108,11 @@
               nixfmt.enable = true;
               rustfmt.enable = true;
               cargo-check.enable = true;
+              typos = {
+                enable = true;
+                types = [ "text" ];
+                excludes = [ "exampledir/.*" ];
+              };
             };
           };
         } // pkgs.lib.optionalAttrs (system == "x86_64-linux") {

--- a/flake.nix
+++ b/flake.nix
@@ -109,11 +109,6 @@
               };
             };
           };
-        } // pkgs.lib.optionalAttrs (system == "x86_64-linux") {
-          # NB: cargo-tarpaulin only supports x86_64 systems
-          # Check code coverage (note: this will not upload coverage anywhere)
-          rga-coverage =
-            craneLib.cargoTarpaulin { inherit buildInputs cargoArtifacts src; };
         };
 
         # `nix build`

--- a/flake.nix
+++ b/flake.nix
@@ -45,10 +45,8 @@
 
         craneLib = crane.lib.${system};
         src = pkgs.lib.cleanSourceWith {
-          src = craneLib.path ./.; # original, unfiltered source
-          filter = path: type:
-            (builtins.match ".*jsonc$" path != null) # include JSONC files
-            || (craneLib.filterCargoSources path type);
+          src = craneLib.path ./.;
+          filter = pkgs.lib.cleanSourceFilter;
         };
 
         buildInputs = with pkgs;
@@ -115,7 +113,7 @@
           # NB: cargo-tarpaulin only supports x86_64 systems
           # Check code coverage (note: this will not upload coverage anywhere)
           rga-coverage =
-            craneLib.cargoTarpaulin { inherit cargoArtifacts src; };
+            craneLib.cargoTarpaulin { inherit buildInputs cargoArtifacts src; };
         };
 
         # `nix build`

--- a/src/adapters/ffmpeg.rs
+++ b/src/adapters/ffmpeg.rs
@@ -54,7 +54,7 @@ struct FFprobeOutput {
 }
 #[derive(Serialize, Deserialize)]
 struct FFprobeStream {
-    index: i32,           // stream index
+    index: i32, // stream index
 }
 
 #[async_trait]
@@ -83,10 +83,14 @@ impl WritingFileAdapter for FFmpegAdapter {
         let subtitle_streams = {
             let probe = Command::new("ffprobe")
                 .args(vec![
-                    "-v", "error",                    // show all errors
-                    "-select_streams", "s",           // show only subtitle streams
-                    "-of", "json",                    // use json as output format
-                    "-show_entries", "stream=index",  // show index of subtitle streams
+                    "-v",
+                    "error", // show all errors
+                    "-select_streams",
+                    "s", // show only subtitle streams
+                    "-of",
+                    "json", // use json as output format
+                    "-show_entries",
+                    "stream=index", // show index of subtitle streams
                 ])
                 .arg("-i")
                 .arg(&inp_fname)
@@ -139,7 +143,8 @@ impl WritingFileAdapter for FFmpegAdapter {
                 // extract subtitles
                 let mut cmd = Command::new("ffmpeg");
                 cmd.arg("-hide_banner")
-                    .arg("-loglevel").arg("panic")
+                    .arg("-loglevel")
+                    .arg("panic")
                     .arg("-i")
                     .arg(&inp_fname)
                     .arg("-map")

--- a/src/adapters/ffmpeg.rs
+++ b/src/adapters/ffmpeg.rs
@@ -134,7 +134,7 @@ impl WritingFileAdapter for FFmpegAdapter {
                 return Err(format_err!("ffprobe failed: {:?}", exit));
             }
         }
-        if subtitle_streams.len() > 0 {
+        if !subtitle_streams.is_empty() {
             for probe_stream in subtitle_streams.iter() {
                 // extract subtitles
                 let mut cmd = Command::new("ffmpeg");
@@ -143,7 +143,7 @@ impl WritingFileAdapter for FFmpegAdapter {
                     .arg("-i")
                     .arg(&inp_fname)
                     .arg("-map")
-                    .arg(format!("0:{}", probe_stream.index.to_string())) // 0 for first input
+                    .arg(format!("0:{}", probe_stream.index)) // 0 for first input
                     .arg("-f")
                     .arg("webvtt")
                     .arg("-");

--- a/src/adapters/sqlite.rs
+++ b/src/adapters/sqlite.rs
@@ -138,7 +138,7 @@ mod test {
 
     #[tokio::test]
     async fn simple() -> Result<()> {
-        let adapter: Box<dyn FileAdapter> = Box::new(SqliteAdapter::default());
+        let adapter: Box<dyn FileAdapter> = Box::<SqliteAdapter>::default();
         let fname = test_data_dir().join("hello.sqlite3");
         let (a, d) = simple_fs_adapt_info(&fname).await?;
         let res = adapter.adapt(a, &d).await?;

--- a/src/preproc_cache.rs
+++ b/src/preproc_cache.rs
@@ -181,7 +181,7 @@ mod test {
     #[tokio::test]
     async fn test_read_write() -> anyhow::Result<()> {
         let path = tempfile::tempdir()?;
-        let db = open_cache_db(&path.path().join("foo.sqlite3")).await?;
+        let _db = open_cache_db(&path.path().join("foo.sqlite3")).await?;
         // db.set();
         Ok(())
     }


### PR DESCRIPTION
Running the CI checks via Nix ensures that we always have a stable set of dependencies to test against.