### PR TITLE
Include runtime dependencies in Nix package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1684981077,
-        "narHash": "sha256-68X9cFm0RTZm8u0rXPbeBzOVUH5OoUGAfeHHVoxGd9o=",
+        "lastModified": 1693787605,
+        "narHash": "sha256-rwq5U8dy+a9JFny/73L0SJu1GfWwATMPMTp7D+mjHy8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "35110cccf28823320f4fd697fcafcb5038683982",
+        "rev": "8b4f7a4dab2120cf41e7957a28a853f45016bd9d",
         "type": "github"
       },
       "original": {
@@ -76,11 +76,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683080331,
-        "narHash": "sha256-nGDvJ1DAxZIwdn6ww8IFwzoHb2rqBP4wv/65Wt5vflk=",
+        "lastModified": 1693707092,
+        "narHash": "sha256-HR1EnynBSPqbt+04/yxxqsG1E3n6uXrOl7SPco/UnYo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d59c3fa0cba8336e115b376c2d9e91053aa59e56",
+        "rev": "98ccb73e6eefc481da6039ee57ad8818d1ca8d56",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -145,16 +145,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1678872516,
-        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -172,11 +172,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1685361114,
-        "narHash": "sha256-4RjrlSb+OO+e1nzTExKW58o3WRwVGpXwj97iCta8aj4=",
+        "lastModified": 1694364351,
+        "narHash": "sha256-oadhSCqopYXxURwIA6/Anpe5IAG11q2LhvTJNP5zE6o=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ca2fdbf3edda2a38140184da6381d49f8206eaf4",
+        "rev": "4f883a76282bc28eb952570afc3d8a1bf6f481d7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -54,15 +54,7 @@
           pkgs.libiconv
         ];
 
-        runtimeInputs = with pkgs; [
-          ffmpeg
-          imagemagick
-          pandoc
-          poppler_utils
-          ripgrep
-          tesseract
-          zip
-        ];
+        runtimeInputs = with pkgs; [ ffmpeg pandoc poppler_utils ripgrep zip ];
 
         # Build *just* the cargo dependencies, so we can reuse
         # all of that work (e.g. via cachix) when running in CI

--- a/flake.nix
+++ b/flake.nix
@@ -49,27 +49,46 @@
           filter = pkgs.lib.cleanSourceFilter;
         };
 
-        buildInputs = with pkgs;
-          [ ffmpeg imagemagick pandoc poppler_utils ripgrep tesseract ]
-          ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-            # Additional darwin specific inputs can be set here
-            pkgs.libiconv
-          ];
+        nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin [
+          # Additional darwin specific inputs can be set here
+          pkgs.libiconv
+        ];
+
+        runtimeInputs = with pkgs; [
+          ffmpeg
+          imagemagick
+          pandoc
+          poppler_utils
+          ripgrep
+          tesseract
+          zip
+        ];
 
         # Build *just* the cargo dependencies, so we can reuse
         # all of that work (e.g. via cachix) when running in CI
-        cargoArtifacts = craneLib.buildDepsOnly { inherit src buildInputs; };
+        cargoArtifacts =
+          craneLib.buildDepsOnly { inherit src nativeBuildInputs; };
 
         # Build the actual crate itself, reusing the dependency
         # artifacts from above.
-        rga = craneLib.buildPackage { inherit cargoArtifacts src buildInputs; };
+        rgaBinary = craneLib.buildPackage {
+          inherit cargoArtifacts src nativeBuildInputs;
+          buildInputs = runtimeInputs; # needed for tests
+        };
+
+        # Provide a shell script of the Rust binary plus runtime dependencies.
+        rga = pkgs.pkgs.writeShellApplication {
+          name = "rga";
+          text = ''rga "$@"'';
+          runtimeInputs = runtimeInputs ++ [ rgaBinary ];
+        };
 
         pre-commit = pre-commit-hooks.lib."${system}".run;
       in {
         # `nix flake check`
         checks = {
           # Build the crate as part of `nix flake check` for convenience
-          inherit rga;
+          inherit rgaBinary;
 
           # Run clippy (and deny all warnings) on the crate source,
           # again, resuing the dependency artifacts from above.
@@ -78,7 +97,7 @@
           # we can block the CI if there are issues here, but not
           # prevent downstream consumers from building our crate by itself.
           rga-clippy = craneLib.cargoClippy {
-            inherit cargoArtifacts src buildInputs;
+            inherit cargoArtifacts src;
             cargoClippyExtraArgs = "--all-targets -- --deny warnings";
           };
 
@@ -92,7 +111,8 @@
 
           # Run tests with cargo-nextest.
           rga-nextest = craneLib.cargoNextest {
-            inherit cargoArtifacts src buildInputs;
+            inherit cargoArtifacts src nativeBuildInputs;
+            buildInputs = runtimeInputs; # needed for tests
             partitions = 1;
             partitionType = "count";
           };
@@ -113,7 +133,7 @@
 
         # `nix build`
         packages = {
-          inherit rga; # `nix build .#rga`
+          inherit rgaBinary rga;
           default = rga; # `nix build`
         };
 
@@ -124,7 +144,7 @@
         devShells.default = craneLib.devShell {
           inherit (self.checks.${system}.pre-commit) shellHook;
           inputsFrom = builtins.attrValues self.checks;
-          packages = buildInputs;
+          packages = runtimeInputs ++ nativeBuildInputs;
         };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -121,11 +121,10 @@
         apps.default = flake-utils.lib.mkApp { drv = rga; };
 
         # `nix develop`
-        devShells.default = pkgs.mkShell {
+        devShells.default = craneLib.devShell {
           inherit (self.checks.${system}.pre-commit) shellHook;
           inputsFrom = builtins.attrValues self.checks;
-          buildInputs = buildInputs
-            ++ (with pkgs; [ cargo nixfmt rustc rustfmt ]);
+          packages = buildInputs;
         };
       });
 }

--- a/src/adapters/postproc.rs
+++ b/src/adapters/postproc.rs
@@ -260,7 +260,7 @@ mod tests {
             .build();
         let res = postproc_pagebreaks(mock).read_to_end(&mut output).await;
         println!("{}", String::from_utf8_lossy(&output));
-        assert!(matches!(res, Ok(_)));
+        assert!(res.is_ok());
         assert_eq!(
             String::from_utf8_lossy(&output),
             "Page 1: Hello\nPage 1: World\nPage 2: Foo Bar\nPage 2: \nPage 3: Test"
@@ -278,7 +278,7 @@ mod tests {
             .build();
         let res = postproc_pagebreaks(mock).read_to_end(&mut output).await;
         println!("{}", String::from_utf8_lossy(&output));
-        assert!(matches!(res, Ok(_)));
+        assert!(res.is_ok());
         assert_eq!(
             String::from_utf8_lossy(&output),
             "Page 1: Hello\nPage 1: World\nPage 2: Foo Bar\nPage 2: \nPage 3: Test"
@@ -316,7 +316,7 @@ PREFIX:Page 3:
             .read_to_end(&mut output)
             .await;
         println!("{}", String::from_utf8_lossy(&output));
-        assert!(matches!(res, Ok(_)));
+        assert!(res.is_ok());
         assert_eq!(output, b"prefix: Hello\nprefix: World");
     }
 


### PR DESCRIPTION
I had thought that these dependencies were already being propagated through from their inclusion as `buildInputs`, but it turns out they were not. The reason I hadn't noticed is because I had most of the packages installed independently, so in my day-to-day usage I didn't see any errors. 🤦