### PR TITLE
Re-enable `typos` hook with `exampledir/` correctly excluded

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,2 +1,5 @@
 [default.extend-words]
 als = "als"
+
+[files]
+extend-exclude = ["exampledir/*"]

--- a/flake.nix
+++ b/flake.nix
@@ -114,7 +114,7 @@
             hooks = {
               nixfmt.enable = true;
               rustfmt.enable = true;
-              typos.enable = false;
+              typos.enable = true;
             };
           };
         };


### PR DESCRIPTION
This effectively reverts commit 28d1f014aabea13df38c2162cbd49a972cc473b8.

Running locally:
```console
$ nix flake check && echo $?        
0
```