### PR TITLE
Add .kra (Krita documents) to zip adapter

### DIFF
--- a/src/adapters/zip.rs
+++ b/src/adapters/zip.rs
@@ -5,7 +5,7 @@ use async_stream::stream;
 use lazy_static::lazy_static;
 use log::*;
 
-static EXTENSIONS: &[&str] = &["zip", "jar"];
+static EXTENSIONS: &[&str] = &["zip", "jar", "kra"];
 
 lazy_static! {
     static ref METADATA: AdapterMeta = AdapterMeta {


### PR DESCRIPTION
[Krita documents are also zip archives](https://docs.krita.org/en/general_concepts/file_formats/file_kra.html), but the accurate matcher doesn't seem to be recognizing them properly. More generally, it'd be nice to have the ability to configure extra associations of file extensions to integrated adapters, rather than needing a patch for every new filetype that's actually a zip archive.