### PR TITLE
add .xpi file extension to .zip adapters

### DIFF
--- a/src/adapters/zip.rs
+++ b/src/adapters/zip.rs
@@ -5,7 +5,7 @@ use async_stream::stream;
 use lazy_static::lazy_static;
 use log::*;
 
-static EXTENSIONS: &[&str] = &["zip", "jar"];
+static EXTENSIONS: &[&str] = &["zip", "jar", "xpi"];
 
 lazy_static! {
     static ref METADATA: AdapterMeta = AdapterMeta {


### PR DESCRIPTION
Add firefox extension (.xpi) format to zip adapter list