### PR TITLE
add support for .snagx zip archives

### DIFF
--- a/src/adapters/zip.rs
+++ b/src/adapters/zip.rs
@@ -5,7 +5,9 @@ use async_stream::stream;
 use lazy_static::lazy_static;
 use log::*;
 
-static EXTENSIONS: &[&str] = &["zip", "jar", "xpi", "kra"];
+// TODO: allow users to configure file extensions instead of hard coding the list
+// https://github.com/phiresky/ripgrep-all/pull/208#issuecomment-2173241243
+static EXTENSIONS: &[&str] = &["zip", "jar", "xpi", "kra", "snagx"];
 
 lazy_static! {
     static ref METADATA: AdapterMeta = AdapterMeta {


### PR DESCRIPTION
closes #233

tested with a release build:
```
hacksore@eloy:~/Downloads
 $ ~/code/opensource/ripgrep-all/target/release/rga "version"             130 ↵
2024-06-21_15-52-06.snagx
index.json:   "Version" : "1.0"
metadata.json:   "AppVersion" : "126.0.6478.62 (6478.62)",
metadata.json:   "OperatingSystemVersion" : "macOS 14.5.0",
metadata.json:   "Version" : "1.0",
{238467DE-913D-47ED-ABE4-2058B4E54A7F}.json:   "SoftwareVersion" : "2024.2.5",
{238467DE-913D-47ED-ABE4-2058B4E54A7F}.json:   "Version" : "1.0"
{238467DE-913D-47ED-ABE4-2058B4E54A7F}.backup.json:   "SoftwareVersion" : "2024.2.5",
{238467DE-913D-47ED-ABE4-2058B4E54A7F}.backup.json:   "Version" : "1.0"

2024-06-22_11-40-21.snagx
index.json:   "Version" : "1.0"
{AC2A4668-56B5-4649-B242-EFD0DFF3EDB7}.json:   "SoftwareVersion" : "2024.2.5",
{AC2A4668-56B5-4649-B242-EFD0DFF3EDB7}.json:   "Version" : "1.0"
{AC2A4668-56B5-4649-B242-EFD0DFF3EDB7}.backup.json:   "SoftwareVersion" : "2024.2.5",
{AC2A4668-56B5-4649-B242-EFD0DFF3EDB7}.backup.json:   "Version" : "1.0"
metadata.json:   "AppVersion" : "126.0.6478.63 (6478.63)",
metadata.json:   "OperatingSystemVersion" : "macOS 14.5.0",
metadata.json:   "Version" : "1.0",

2024-06-21_15-21-54.snagx
index.json:   "Version" : "1.0"
metadata.json:   "AppVersion" : "0.0.308 (0.0.308)",
metadata.json:   "OperatingSystemVersion" : "macOS 14.5.0",
metadata.json:   "Version" : "1.0",
{7B3953F6-0583-4217-874B-6191BD336EEC}.json:   "SoftwareVersion" : "2024.2.5",
{7B3953F6-0583-4217-874B-6191BD336EEC}.json:   "Version" : "1.0"
{7B3953F6-0583-4217-874B-6191BD336EEC}.backup.json:   "SoftwareVersion" : "2024.2.5",
{7B3953F6-0583-4217-874B-6191BD336EEC}.backup.json:   "Version" : "1.0"
```