### PR TITLE
Add support for cargo binstall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,12 @@ tokio-test = "0.4.2"
 [profile.release]
 debug = true
 split-debuginfo = "packed"
+
+# The following metadata is used by `cargo-binstall`, and should be synchronized
+# with `.github/workflows/release.yml`.
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.{ archive-format }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"


### PR DESCRIPTION
Hello i think it work i try with the command and it seem to works

```sh
cargo binstall --pkg-url="{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.{ archive-format }"--pkg-fmt="txz"  ripgrep_all
```