### PR TITLE
feat: add xlsx and ods general fallback support

### DIFF
--- a/src/adapters/zip.rs
+++ b/src/adapters/zip.rs
@@ -7,7 +7,7 @@ use log::*;
 
 // TODO: allow users to configure file extensions instead of hard coding the list
 // https://github.com/phiresky/ripgrep-all/pull/208#issuecomment-2173241243
-static EXTENSIONS: &[&str] = &["zip", "jar", "xpi", "kra", "snagx"];
+static EXTENSIONS: &[&str] = &["zip", "jar", "xpi", "kra", "snagx", "xlsx", "ods"];
 
 lazy_static! {
     static ref METADATA: AdapterMeta = AdapterMeta {


### PR DESCRIPTION
## Background

I attempted to use Custom Adapter suggested in https://github.com/phiresky/ripgrep-all/issues/36#issuecomment-1564507761 and configure like this

```jsonc
{
  "name": "spreadsheet",
  "version": 1,
  "description": "Spreadsheet like ods is supported in the search",
  "extensions": ["ods"],
  "mimetypes": ["application/vnd.oasis.opendocument.spreadsheet"],
  "binary": "unzip",
  // Placeholders:
  //
  // - $input_file_extension: the file extension (without dot). e.g.
  //   foo.tar.gz -> gz
  // - $input_file_stem, the file name without the last extension. e.g.
  //   foo.tar.gz -> foo.tar
  // - $input_virtual_path: the full input file path. Note that this path
  //   may not actually exist on disk because it is the result of another
  //   adapter stdin of the program will be connected to the input file, and
  //   stdout is assumed to be the converted file
  "args": ["-U", "-aa", "-p", "$input_virtual_path", "content.xml"],
  "disabled_by_default": false,
  "match_only_by_mime": false
}
```

However, it did not show the match and always show unknown error like

```
.\notes.ods: WARNING: stopped searching binary file after match (found "\0" byte around offset 22863)
```

Even I just put command line (`binary` and `args` in the config) to terminal and run successfully without no issue.

```
> unzip -U -aa -p .\notes.ods content.xml
<?xml version="1.0" encoding="UTF-8"?>
<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:rpt="http://openoffice.org/2005/report" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" office:version="1.3"><office:scripts/><office:font-face-decls><style:font-face style:name="Liberation Sans" svg:font-family="&apos;Liberation Sans&apos;" style:font-family-generic="swiss" style:font-pitch="variable"/><style:font-face style:name="Lucida Sans" svg:font-family="&apos;Lucida Sans&apos;" style:font-family-generic="system" style:font-pitch="variable"/><style:font-face style:name="思源黑体 Normal" svg:font-family="&apos;思源黑体 Normal&apos;" style:font-family-generic="system" style:font-pitch="variable"/></office:font-face-decls><office:automatic-styles><style:style style:name="co1" style:family="table-column"><style:table-column-properties fo:break-before="auto" style:column-width="0.499cm"/></style:style><style:style style:name="ro1" style:family="table-row"><style:table-row-properties style:row-height="0.499cm" fo:break-before="auto" style:use-optimal-row-height="false"/></style:style><style:style style:name="ta1" style:family="table" style:master-page-name="Default"><style:table-properties table:display="true" style:writing-mode="lr-tb"/></style:style><style:style style:name="ce1" style:family="table-cell" style:parent-style-name="Default"><style:text-properties fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/></style:style><style:style style:name="ce2" style:family="table-cell" style:parent-style-name="Default"><style:text-properties fo:font-size="9pt" fo:font-weight="bold" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/></style:style></office:automatic-styles><office:body><office:spreadsheet><table:calculation-settings table:automatic-find-labels="false" table:use-regular-expressions="false" table:use-wildcards="true"/><table:table table:name="template" table:style-name="ta1"><table:table-column table:style-name="co1" table:number-columns-repeated="16384" table:default-cell-style-name="ce1"/><table:table-row table:style-name="ro1" table:number-rows-repeated="1048575"><table:table-cell table:number-columns-repeated="16384"/></table:table-row><table:table-row table:style-name="ro1"><table:table-cell table:number-columns-repeated="16384"/></table:table-row></table:table><table:table table:name="2024-W33-5-general-boot" table:style-name="ta1"><table:table-column table:style-name="co1" table:number-columns-repeated="16384" table:default-cell-style-name="ce1"/><table:table-row table:style-name="ro1"><table:table-cell table:number-columns-repeated="16384"/></table:table-row><table:table-row table:style-name="ro1"><table:table-cell/><table:table-cell office:value-type="string" calcext:value-type="string"><text:p>启动的一般顺序</text:p></table:table-cell><table:table-cell table:number-columns-repeated="16382"/></table:table-row><table:table-row table:style-name="ro1"><table:table-cell table:number-columns-repeated="16384"/></table:table-row><table:table-row table:style-name="ro1"><table:table-cell table:style-name="ce2"/><table:table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string"><text:p>阶段</text:p></table:table-cell><table:table-cell table:style-name="ce2" table:number-columns-repeated="4"/><table:table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string"><text:p>组件</text:p></table:table-cell><table:table-cell table:style-name="ce2" table:number-columns-repeated="3"/><table:table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string"><text:p>功能</text:p></table:table-cell><table:table-cell table:style-name="ce2" table:number-columns-repeated="16373"/></table:table-row><table:table-row table:style-name="ro1"><table:table-cell/><table:table-cell office:value-type="string" calcext:value-type="string"><text:p>上电、引导</text:p></table:table-cell><table:table-cell table:number-columns-repeated="4"/><table:table-cell office:value-type="string" calcext:value-type="string"><text:p>开关</text:p></table:table-cell><table:table-cell table:number-columns-repeated="3"/><table:table-cell office:value-type="string" calcext:value-type="string"><text:p>为主板通电</text:p></table:table-cell><table:table-cell table:number-columns-repeated="16373"/></table:table-row><table:table-row table:style-name="ro1"><table:table-cell table:number-columns-repeated="6"/><table:table-cell office:value-type="string" calcext:value-type="string"><text:p>主板引脚</text:p></table:table-cell><table:table-cell table:number-columns-repeated="16377"/></table:table-row><table:table-row table:style-name="ro1"><table:table-cell table:number-columns-repeated="6"/><table:table-cell office:value-type="string" calcext:value-type="string"><text:p>电源</text:p></table:table-cell><table:table-cell table:number-columns-repeated="16377"/></table:table-row><table:table-row table:style-name="ro1" table:number-rows-repeated="1048568"><table:table-cell table:number-columns-repeated="16384"/></table:table-row><table:table-row table:style-name="ro1"><table:table-cell table:number-columns-repeated="16384"/></table:table-row></table:table><table:named-expressions/></office:spreadsheet></office:body></office:document-content>
```

From reading code, just found this line https://github.com/phiresky/ripgrep-all/blob/e207c1229f617672483f668826fe5ce92da57d45/src/adapters/zip.rs#L10 is hard coded. And essentially, `ods` and `xlsx` is zip archived and can be searched from extraction.

## Purpose

Just provide a fallback general availability to search zipped document that not supported by pandoc or other tools etc. If custom adapter is configured, it will use custom adapter rather than this config. `.epub` can be considered as a zipped package if following this idea.

## Further

Basically it's just adhoc tweak, but hopefully provide a temporary mitigation for the pains from users. If we have any better perm/adboc solution, I'm glad to help on that.