### PR TITLE
Enable thin LTO for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,4 +71,5 @@ tokio-test = "0.4.2"
 
 [profile.release]
 debug = true
+lto = "thin"
 split-debuginfo = "packed"


### PR DESCRIPTION
See https://doc.rust-lang.org/cargo/reference/profiles.html#release for the release profile's defaults and https://doc.rust-lang.org/cargo/reference/profiles.html#lto for an explanation of link time optimizations (LTO).

Resolves https://github.com/phiresky/ripgrep-all/issues/254, which is where enabling thin LTO was first suggested.