### PR TITLE
Use separate config properties for adapter enable/disable lists

### DIFF
--- a/src/adapters/custom.rs
+++ b/src/adapters/custom.rs
@@ -25,32 +25,48 @@ use tokio_util::io::StreamReader;
 // mostly the same as AdapterMeta + SpawningFileAdapter
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Default, PartialEq, Clone)]
 pub struct CustomAdapterConfig {
-    /// the unique identifier and name of this adapter. Must only include a-z, 0-9, _
+    /// The unique identifier and name of this adapter.
+    ///
+    /// Must only include a-z, 0-9, _.
     pub name: String,
-    /// a description of this adapter. shown in help
+
+    /// The description of this adapter shown in help.
     pub description: String,
-    /// if true, the adapter will be disabled by default
+
+    /// If true, the adapter will be disabled by default.
     pub disabled_by_default: Option<bool>,
-    /// version identifier. used to key cache entries, change if the configuration or program changes
+
+    /// Version identifier used to key cache entries.
+    ///
+    /// Change this if the configuration or program changes.
     pub version: i32,
-    /// the file extensions this adapter supports. For example ["epub", "mobi"]
+
+    /// The file extensions this adapter supports, for example `["epub", "mobi"]`.
     pub extensions: Vec<String>,
-    /// if not null and --rga-accurate is enabled, mime type matching is used instead of file name matching
+
+    /// If not null and `--rga-accurate` is enabled, mimetype matching is used instead of file name matching.
     pub mimetypes: Option<Vec<String>>,
-    /// if --rga-accurate, only match by mime types, ignore extensions completely
+
+    /// If `--rga-accurate`, only match by mime types and ignore extensions completely.
     pub match_only_by_mime: Option<bool>,
-    /// the name or path of the binary to run
+
+    /// The name or path of the binary to run.
     pub binary: String,
-    /// The arguments to run the program with. Placeholders:
-    /// - $input_file_extension: the file extension (without dot). e.g. foo.tar.gz -> gz
-    /// - $input_file_stem, the file name without the last extension. e.g. foo.tar.gz -> foo.tar
-    /// - $input_virtual_path: the full input file path. Note that this path may not actually exist on disk because it is the result of another adapter
+
+    /// The arguments to run the program with.
+    /// Placeholders:
+    /// - `$input_file_extension`: the file extension (without dot). e.g. foo.tar.gz -> gz
+    /// - `$input_file_stem`: the file name without the last extension. e.g. foo.tar.gz -> foo.tar
+    /// - `$input_virtual_path`: the full input file path.
+    ///   Note that this path may not actually exist on disk because it is the result of another adapter.
     ///
     /// stdin of the program will be connected to the input file, and stdout is assumed to be the converted file
     pub args: Vec<String>,
-    /// The output path hint. The placeholders are the same as for `.args`
+
+    /// The output path hint.
+    /// The placeholders are the same as for `.args`
     ///
-    /// If not set, defaults to "${input_virtual_path}.txt"
+    /// If not set, defaults to `"${input_virtual_path}.txt"`.
     ///
     /// Setting this is useful if the output format is not plain text (.txt) but instead some other format that should be passed to another adapter
     pub output_path_hint: Option<String>,

--- a/src/bin/rga.rs
+++ b/src/bin/rga.rs
@@ -12,7 +12,11 @@ use std::process::Command;
 use std::time::Instant;
 
 fn list_adapters(args: RgaConfig) -> Result<()> {
-    let (enabled_adapters, disabled_adapters) = get_all_adapters(args.custom_adapters);
+    let (enabled_adapters, disabled_adapters) = get_all_adapters(
+        args.custom_adapters,
+        &args.adapters_enable,
+        &args.adapters_disable,
+    );
 
     println!("Adapters:\n");
     let print = |adapter: std::sync::Arc<dyn FileAdapter>| {
@@ -87,7 +91,12 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let adapters = get_adapters_filtered(config.custom_adapters.clone(), &config.adapters)?;
+    let adapters = get_adapters_filtered(
+        config.custom_adapters.clone(),
+        &config.adapters_enable,
+        &config.adapters_disable,
+        &config.adapters,
+    )?;
 
     let pre_glob = if !config.accurate {
         let extensions = adapters

--- a/src/config.rs
+++ b/src/config.rs
@@ -130,13 +130,26 @@ pub struct RgaConfig {
     /// - "foo,bar" means use only adapters foo and bar.
     /// - "-bar,baz" means use all default adapters except for bar and baz.
     /// - "+bar,baz" means use all default adapters and also bar and baz.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(skip)] // CLI only
     #[structopt(
         long = "--rga-adapters",
         require_equals = true,
         require_delimiter = true
     )]
     pub adapters: Vec<String>,
+
+    /// Additional adapters to enable in addition to any default adapters.
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[structopt(skip)] // config file only
+    pub adapters_enable: Vec<String>,
+
+    /// Adapters to explicitly disable.
+    ///
+    /// Entries in this list will overrule those in `adapters_enable`;
+    /// if the same adapter is present in both lists it will be disabled.
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[structopt(skip)] // config file only
+    pub adapters_disable: Vec<String>,
 
     #[serde(default, skip_serializing_if = "is_default")]
     #[structopt(flatten)]
@@ -378,7 +391,7 @@ where
             )
         })?;
     {
-        // readd values with [serde(skip)]
+        // read values with [serde(skip)]
         res.fzf_path = arg_matches.fzf_path;
         res.list_adapters = arg_matches.list_adapters;
         res.print_config_schema = arg_matches.print_config_schema;

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -32,7 +32,12 @@ async fn choose_adapter(
     archive_recursion_depth: i32,
     inp: &mut (impl AsyncBufRead + Unpin),
 ) -> Result<Option<(Arc<dyn FileAdapter>, FileMatcher, ActiveAdapters)>> {
-    let active_adapters = get_adapters_filtered(config.custom_adapters.clone(), &config.adapters)?;
+    let active_adapters = get_adapters_filtered(
+        config.custom_adapters.clone(),
+        &config.adapters_enable,
+        &config.adapters_disable,
+        &config.adapters,
+    )?;
     let adapters = adapter_matcher(&active_adapters, config.accurate)?;
     let filename = filepath_hint
         .file_name()


### PR DESCRIPTION
The `adapters` property in the configuration file is replaced by two new properties, `adapters_enable` and `adapters_disable`. The CLI is unchanged; the new properties are only supported in the config file and can be overridden by the `--adapters` CLI option.

This is intended to resolve #183 by making it clearer how to enable or disable adapters via the config file.