### PR TITLE
check OS to use appropriate program to open files in rga-fzf

### DIFF
--- a/src/bin/rga-fzf-open.rs
+++ b/src/bin/rga-fzf-open.rs
@@ -10,10 +10,16 @@ fn main() -> anyhow::Result<()> {
     let query = args.next().context("no query")?;
     let fname = args.next().context("no filename")?;
     // let instance_id = std::env::var("RGA_FZF_INSTANCE").unwrap_or("unk".to_string());
+    use std::env;
 
+    let (cmd, pdf_cmd) = match env::consts::OS {
+        "macos" => ("open", "open -a Preview.app"), // use native Preview for macOs
+        "linux" => ("xdg-open", "evince"),          // use evince for linux
+        &_ => ("", ""),
+    };
     if fname.ends_with(".pdf") {
         use std::io::ErrorKind::*;
-        let worked = Command::new("evince")
+        let worked = Command::new(pdf_cmd)
             .arg("--find")
             .arg(&query)
             .arg(&fname)
@@ -29,7 +35,6 @@ fn main() -> anyhow::Result<()> {
             return Ok(());
         }
     }
-    Command::new("xdg-open").arg(fname).spawn()?;
-
+    Command::new(cmd).arg(fname).spawn()?;
     Ok(())
 }


### PR DESCRIPTION
Replace hardcoding `evince` to open pdfs and `xdg-open` to open other files when using `rga-fzf` use those if the OS is Linux, and use `open` if the OS is macOs. If the OS is neither macOs nor Linux, it fails to open. I didn’t add an option for Windows because I’m not familiar enough with it to suggest a program.

This is intended to fix https://github.com/phiresky/ripgrep-all/issues/240 and https://github.com/phiresky/ripgrep-all/issues/253 by checking the OS before running `xdg-open` and `evince`.