### PR TITLE
Update to Rust 1.85 and edition 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
 dependencies = [
  "backtrace",
 ]
@@ -164,7 +164,7 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
 dependencies = [
- "bzip2",
+ "bzip2 0.4.4",
  "flate2",
  "futures-core",
  "memchr",
@@ -177,12 +177,12 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+checksum = "06575e6a9673580f52661c92107baabffbf41e2141373441cbcdc47cb733003c"
 dependencies = [
  "brotli",
- "bzip2",
+ "bzip2 0.5.2",
  "deflate64",
  "flate2",
  "futures-core",
@@ -191,8 +191,8 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "xz2",
- "zstd 0.13.2",
- "zstd-safe 7.2.1",
+ "zstd 0.13.3",
+ "zstd-safe 7.2.3",
 ]
 
 [[package]]
@@ -309,9 +309,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "brotli"
@@ -357,21 +357,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "bzip2-sys"
-version = "0.1.12+1.0.8"
+name = "bzip2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ebc2f1a417f01e1da30ef264ee86ae31d2dcd2d603ea283d3c244a883ca2a9"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -396,14 +404,14 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -423,18 +431,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.29"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.29"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -654,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -706,9 +714,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1002,9 +1010,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libredox"
@@ -1012,7 +1020,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "libc",
  "redox_syscall",
 ]
@@ -1046,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "lzma-sys"
@@ -1092,9 +1100,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -1300,9 +1308,9 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "pretty-bytes"
@@ -1374,11 +1382,11 @@ checksum = "640c9bd8497b02465aeef5375144c26062e0dcd5939dfcbb0f5db76cb8c17c73"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -1427,14 +1435,14 @@ version = "0.10.6"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
- "async-compression 0.4.18",
+ "async-compression 0.4.19",
  "async-recursion",
  "async-stream",
  "async-trait",
  "async_zip",
  "bincode",
  "bytes",
- "clap 4.5.29",
+ "clap 4.5.31",
  "crossbeam",
  "crossbeam-channel",
  "ctor",
@@ -1479,7 +1487,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78046161564f5e7cd9008aff3b2990b3850dc8e0349119b98e8f251e099f24d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -1514,7 +1522,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1535,9 +1543,9 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "schemars"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
@@ -1548,9 +1556,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1572,18 +1580,18 @@ checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1603,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
  "itoa",
  "memchr",
@@ -1649,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
@@ -1723,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1880,15 +1888,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2040,6 +2048,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,7 +2141,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -2187,11 +2201,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
- "zstd-safe 7.2.1",
+ "zstd-safe 7.2.3",
 ]
 
 [[package]]
@@ -2206,18 +2220,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.1"
+version = "7.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+checksum = "f3051792fbdc2e1e143244dc28c60f73d8470e93f3f9cbd0ead44da5ed802722"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.14+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,7 @@
-
 [package]
 authors = ["phiresky <phireskyde+git@gmail.com>"]
 description = "rga: ripgrep, but also search in PDFs, E-Books, Office documents, zip, tar.gz, etc."
-edition = "2021"
+edition = "2024"
 exclude = [
   "exampledir/*",
 ]

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1739520703,
-        "narHash": "sha256-UqR1f9gThWNBCBobWet7T46vTSxkB6dVAdeqNBoF8mc=",
+        "lastModified": 1740407442,
+        "narHash": "sha256-EGzWKm5cUDDJbwVzxSB4N/+CIVycwOG60Gh5f1Vp7JM=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "ddccfe8aced779f7b54d27bbe7e122ecb1dda33a",
+        "rev": "2e25d9665f10de885c81a9fb9d51a289f625b05f",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1739815359,
-        "narHash": "sha256-mjB72/7Fgk5bsIIKA4G9LkIb/u0Ci+VdOyQSgBuQtjo=",
+        "lastModified": 1739936662,
+        "narHash": "sha256-x4syUjNUuRblR07nDPeLDP7DpphaBVbUaSoeZkFbGSk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "282159b2b0588b87a9dbcc40decc91dd5bed5c89",
+        "rev": "19de14aaeb869287647d9461cbd389187d8ecdb7",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739820476,
-        "narHash": "sha256-yf/6fdaOmV2FrlfbZ1AShQDNtNZPYd5HrGDh8VlnDI8=",
+        "lastModified": 1740711547,
+        "narHash": "sha256-qvixVB2cFGOX/B//KbjKUndrMbIDEGBx7xphitqnvr8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f5af08101334aaa196c9a964893d7ddf0196f64",
+        "rev": "2ca95eef7e3b33ea8b858ed025e492373aca8106",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739759407,
-        "narHash": "sha256-YIrVxD2SaUyaEdMry2nAd2qG1E0V38QIV6t6rpguFwk=",
+        "lastModified": 1740709839,
+        "narHash": "sha256-4dF++MXIXna/AwlZWDKr7bgUmY4xoEwvkF1GewjNrt0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6e6ae2acf4221380140c22d65b6c41f4726f5932",
+        "rev": "b4270835bf43c6f80285adac6f66a26d83f0f277",
         "type": "github"
       },
       "original": {

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -57,8 +57,8 @@ impl AdapterMeta {
             self.keep_fast_matchers_if_accurate,
             &self.slow_matchers,
         ) {
-            (true, false, Some(ref sm)) => Box::new(sm.iter().map(Cow::Borrowed)),
-            (true, true, Some(ref sm)) => Box::new(
+            (true, false, Some(sm)) => Box::new(sm.iter().map(Cow::Borrowed)),
+            (true, true, Some(sm)) => Box::new(
                 sm.iter().map(Cow::Borrowed).chain(
                     self.fast_matchers
                         .iter()

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -9,10 +9,10 @@ pub mod tar;
 pub mod writing;
 pub mod zip;
 use crate::{adapted_iter::AdaptedFilesIterBox, config::RgaConfig, matching::*};
-use anyhow::{format_err, Context, Result};
+use anyhow::{Context, Result, format_err};
 use async_trait::async_trait;
-use custom::CustomAdapterConfig;
 use custom::BUILTIN_SPAWNING_ADAPTERS;
+use custom::CustomAdapterConfig;
 use log::*;
 use tokio::io::AsyncRead;
 

--- a/src/adapters/decompress.rs
+++ b/src/adapters/decompress.rs
@@ -52,9 +52,9 @@ impl GetMetadata for DecompressAdapter {
 }
 
 fn decompress_any(reason: &FileMatcher, inp: ReadBox) -> Result<ReadBox> {
-    use async_compression::tokio::bufread;
     use FastFileMatcher::*;
     use FileMatcher::*;
+    use async_compression::tokio::bufread;
     let gz = |inp: ReadBox| Box::pin(bufread::GzipDecoder::new(BufReader::new(inp)));
     let bz2 = |inp: ReadBox| Box::pin(bufread::BzDecoder::new(BufReader::new(inp)));
     let xz = |inp: ReadBox| Box::pin(bufread::XzDecoder::new(BufReader::new(inp)));

--- a/src/adapters/mbox.rs
+++ b/src/adapters/mbox.rs
@@ -186,7 +186,10 @@ mod tests {
             );
             let mut buf = Vec::new();
             file.inp.read_to_end(&mut buf).await?;
-            assert_eq!("<html>\r\n  <head>\r\n    <meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\">\r\n  </head>\r\n  <body>\r\n    <p>&gt;From</p>\r\n    <p>Another word &gt;From<br>\r\n    </p>\r\n  </body>\r\n</html>", String::from_utf8(buf)?.trim());
+            assert_eq!(
+                "<html>\r\n  <head>\r\n    <meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\">\r\n  </head>\r\n  <body>\r\n    <p>&gt;From</p>\r\n    <p>Another word &gt;From<br>\r\n    </p>\r\n  </body>\r\n</html>",
+                String::from_utf8(buf)?.trim()
+            );
             count += 1;
         }
         assert_eq!(3, count);
@@ -224,7 +227,10 @@ mod tests {
                     );
                 }
                 "short.pdf.txt" => {
-                    assert_eq!("PREFIX:Page 1: hello world\nPREFIX:Page 1: this is just a test.\nPREFIX:Page 1: \nPREFIX:Page 1: 1\nPREFIX:Page 1: \nPREFIX:Page 1: \n", String::from_utf8(buf).unwrap_or("err".to_owned()));
+                    assert_eq!(
+                        "PREFIX:Page 1: hello world\nPREFIX:Page 1: this is just a test.\nPREFIX:Page 1: \nPREFIX:Page 1: 1\nPREFIX:Page 1: \nPREFIX:Page 1: \n",
+                        String::from_utf8(buf).unwrap_or("err".to_owned())
+                    );
                 }
                 _ => {
                     panic!("unrelated {path:?}");

--- a/src/adapters/postproc.rs
+++ b/src/adapters/postproc.rs
@@ -17,8 +17,8 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio_util::io::ReaderStream;
 use tokio_util::io::StreamReader;
 
-use crate::adapted_iter::one_file;
 use crate::adapted_iter::AdaptedFilesIterBox;
+use crate::adapted_iter::one_file;
 use crate::matching::FastFileMatcher;
 
 use super::{AdaptInfo, AdapterMeta, FileAdapter, GetMetadata};
@@ -129,7 +129,10 @@ async fn postproc_encoding(
 }
 
 /// Adds the given prefix to each line in an `AsyncRead`.
-pub fn postproc_prefix(line_prefix: &str, inp: impl AsyncRead + Send) -> impl AsyncRead + Send {
+pub fn postproc_prefix<T: AsyncRead + Send>(
+    line_prefix: &str,
+    inp: T,
+) -> impl AsyncRead + Send + use<T> {
     let line_prefix_n = format!("\n{line_prefix}"); // clone since we need it later
     let line_prefix_o = Bytes::copy_from_slice(line_prefix.as_bytes());
     let regex = regex::bytes::Regex::new("\n").unwrap();

--- a/src/adapters/writing.rs
+++ b/src/adapters/writing.rs
@@ -17,12 +17,12 @@ pub trait WritingFileAdapter: GetMetadata + Send + Sync + Clone {
 }
 
 macro_rules! async_writeln {
-    ($dst: expr) => {
+    ($dst: expr_2021) => {
         {
             tokio::io::AsyncWriteExt::write_all(&mut $dst, b"\n").await
         }
     };
-    ($dst: expr, $fmt: expr) => {
+    ($dst: expr_2021, $fmt: expr_2021) => {
         {
             use std::io::Write;
             let mut buf = Vec::<u8>::new();
@@ -30,7 +30,7 @@ macro_rules! async_writeln {
             tokio::io::AsyncWriteExt::write_all(&mut $dst, &buf).await
         }
     };
-    ($dst: expr, $fmt: expr, $($arg: tt)*) => {
+    ($dst: expr_2021, $fmt: expr_2021, $($arg: tt)*) => {
         {
             use std::io::Write;
             let mut buf = Vec::<u8>::new();

--- a/src/adapters/zip.rs
+++ b/src/adapters/zip.rs
@@ -194,7 +194,7 @@ impl<'a> AdaptedFilesIter for ZipAdaptIter<'a> {
 
 #[cfg(test)]
 mod test {
-    use async_zip::{write::ZipFileWriter, Compression, ZipEntryBuilder};
+    use async_zip::{Compression, ZipEntryBuilder, write::ZipFileWriter};
 
     use super::*;
     use crate::{preproc::loop_adapt, test_utils::*};

--- a/src/bin/rga.rs
+++ b/src/bin/rga.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use rga::adapters::custom::map_exe_error;
 use rga::adapters::*;
-use rga::config::{split_args, RgaConfig};
+use rga::config::{RgaConfig, split_args};
 use rga::matching::*;
 use rga::print_dur;
 use ripgrep_all as rga;
@@ -48,7 +48,9 @@ fn list_adapters(args: RgaConfig) -> Result<()> {
     for adapter in enabled_adapters {
         print(adapter)
     }
-    println!("The following adapters are disabled by default, and can be enabled using '--rga-adapters=+foo,bar':\n");
+    println!(
+        "The following adapters are disabled by default, and can be enabled using '--rga-adapters=+foo,bar':\n"
+    );
     for adapter in disabled_adapters {
         print(adapter)
     }

--- a/src/bin/rga.rs
+++ b/src/bin/rga.rs
@@ -57,7 +57,8 @@ fn list_adapters(args: RgaConfig) -> Result<()> {
 fn main() -> anyhow::Result<()> {
     // set debugging as early as possible
     if std::env::args().any(|e| e == "--debug") {
-        std::env::set_var("RUST_LOG", "debug");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("RUST_LOG", "debug") };
     }
 
     env_logger::init();
@@ -151,6 +152,7 @@ fn add_exe_to_path() -> Result<()> {
     // may be somewhat of a security issue if rga binary is in installed in unprivileged locations
     let paths = [&[exe.to_owned(), exe.join("lib")], &paths[..]].concat();
     let new_path = env::join_paths(paths)?;
-    env::set_var("PATH", new_path);
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { env::set_var("PATH", new_path) };
     Ok(())
 }

--- a/src/caching_writer.rs
+++ b/src/caching_writer.rs
@@ -52,7 +52,7 @@ pub fn async_read_and_write_to_cache<'a>(
         trace!("eof");
         // EOF, call on_finish
         let finish = {
-            if let Some(mut writer) = zstd_writer.take() {
+            match zstd_writer.take() { Some(mut writer) => {
                 writer.shutdown().await?;
                 let res = writer.into_inner();
                 trace!("EOF");
@@ -63,9 +63,9 @@ pub fn async_read_and_write_to_cache<'a>(
                     trace!("cache longer than max, dropping");
                     (bytes_written, None)
                 }
-            } else {
+            } _ => {
                 (bytes_written, None)
-            }
+            }}
         };
 
         // EOF, finish!

--- a/src/config.rs
+++ b/src/config.rs
@@ -361,7 +361,8 @@ where
                 serde_json::to_string_pretty(&merged_config)?
             );
             // pass to child processes
-            std::env::set_var(RGA_CONFIG, merged_config.to_string());
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::set_var(RGA_CONFIG, merged_config.to_string()) };
             merged_config
         }
     };

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -57,7 +57,7 @@ pub fn extension_to_regex(extension: &str) -> Regex {
 pub fn adapter_matcher(
     adapters: &[Arc<dyn FileAdapter>],
     slow: bool,
-) -> Result<impl Fn(FileMeta) -> Option<(Arc<dyn FileAdapter>, FileMatcher)>> {
+) -> Result<impl Fn(FileMeta) -> Option<(Arc<dyn FileAdapter>, FileMatcher)> + use<>> {
     // need order later
     let adapter_names: Vec<String> = adapters.iter().map(|e| e.metadata().name.clone()).collect();
     let mut fname_regexes = vec![];

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -6,7 +6,7 @@ use crate::matching::*;
 use crate::preproc_cache::CacheKey;
 use crate::recurse::concat_read_streams;
 use crate::{
-    preproc_cache::{open_cache_db, PreprocCache},
+    preproc_cache::{PreprocCache, open_cache_db},
     print_bytes,
 };
 use anyhow::*;

--- a/src/preproc_cache.rs
+++ b/src/preproc_cache.rs
@@ -188,7 +188,7 @@ impl PreprocCache for SqliteCache {
     }
 }
 /// opens a default cache
-pub async fn open_cache_db(path: &Path) -> Result<impl PreprocCache> {
+pub async fn open_cache_db(path: &Path) -> Result<impl PreprocCache + use<>> {
     std::fs::create_dir_all(path)?;
     SqliteCache::new(path).await
 }

--- a/src/preproc_cache.rs
+++ b/src/preproc_cache.rs
@@ -2,7 +2,7 @@ use crate::{adapters::FileAdapter, preproc::ActiveAdapters};
 use anyhow::{Context, Result};
 use log::warn;
 use path_clean::PathClean;
-use rusqlite::{named_params, OptionalExtension};
+use rusqlite::{OptionalExtension, named_params};
 use std::{path::Path, time::UNIX_EPOCH};
 use tokio_rusqlite::Connection;
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,8 +1,8 @@
 use crate::{
     adapted_iter::AdaptedFilesIterBox,
     adapters::{
-        custom::{CustomSpawningFileAdapter, BUILTIN_SPAWNING_ADAPTERS},
         AdaptInfo, ReadBox,
+        custom::{BUILTIN_SPAWNING_ADAPTERS, CustomSpawningFileAdapter},
     },
     config::RgaConfig,
     matching::{FastFileMatcher, FileMatcher},


### PR DESCRIPTION
From the Rust release team's [announcement on 2025-02-20](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html):

> The Rust team is happy to announce a new version of Rust, 1.85.0. This stabilizes the 2024 edition as well. Rust is a programming language empowering everyone to build reliable and efficient software.

Flake lock file updates:

- Updated input 'advisory-db':
  - From: 'github:rustsec/advisory-db/ddccfe8aced779f7b54d27bbe7e122ecb1dda33a?narHash=sha256-UqR1f9gThWNBCBobWet7T46vTSxkB6dVAdeqNBoF8mc%3D' (2025-02-14)
  - To: 'github:rustsec/advisory-db/2e25d9665f10de885c81a9fb9d51a289f625b05f?narHash=sha256-EGzWKm5cUDDJbwVzxSB4N/%2BCIVycwOG60Gh5f1Vp7JM%3D' (2025-02-24)
- Updated input 'crane':
  - From: 'github:ipetkov/crane/282159b2b0588b87a9dbcc40decc91dd5bed5c89?narHash=sha256-mjB72/7Fgk5bsIIKA4G9LkIb/u0Ci%2BVdOyQSgBuQtjo%3D' (2025-02-17)
  - To: 'github:ipetkov/crane/19de14aaeb869287647d9461cbd389187d8ecdb7?narHash=sha256-x4syUjNUuRblR07nDPeLDP7DpphaBVbUaSoeZkFbGSk%3D' (2025-02-19)
- Updated input 'nixpkgs':
  - From: 'github:NixOS/nixpkgs/8f5af08101334aaa196c9a964893d7ddf0196f64?narHash=sha256-yf/6fdaOmV2FrlfbZ1AShQDNtNZPYd5HrGDh8VlnDI8%3D' (2025-02-17)
  - To: 'github:NixOS/nixpkgs/2ca95eef7e3b33ea8b858ed025e492373aca8106?narHash=sha256-qvixVB2cFGOX/B//KbjKUndrMbIDEGBx7xphitqnvr8%3D' (2025-02-28)
- Updated input 'rust-overlay':
  - From: 'github:oxalica/rust-overlay/6e6ae2acf4221380140c22d65b6c41f4726f5932?narHash=sha256-YIrVxD2SaUyaEdMry2nAd2qG1E0V38QIV6t6rpguFwk%3D' (2025-02-17)
  - To: 'github:oxalica/rust-overlay/b4270835bf43c6f80285adac6f66a26d83f0f277?narHash=sha256-4dF%2B%2BMXIXna/AwlZWDKr7bgUmY4xoEwvkF1GewjNrt0%3D' (2025-02-28)