### PR TITLE
Added x install Support for ripgrep-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ To install the dependencies that are each not strictly necessary but very useful
 
 `brew install pandoc poppler ffmpeg`
 
+### X-CMD
+
+If you are a user of [x-cmd](https://x-cmd.com/install/rga), you can run:
+
+`x install rga`
+
 ### MacPorts
 
 `rga` can also be installed on macOS via [MacPorts](https://ports.macports.org/port/ripgrep-all/):


### PR DESCRIPTION
Hi there,

I've updated the README to include x install from the x-cmd ecosystem, making ripgrep-all installation easier across different platforms and package managers.

I've also created an introduction page:
👉 https://x-cmd.com/install/rga

Hope this helps! Let me know if any changes are needed.

Thanks!